### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pkg-resources==0.0.0
+econ-ark==0.10.7
 PyYAML==5.3.1


### PR DESCRIPTION
This PR addresses #1, and elaborates on #2 (as Seb is busy with more important duties). It does the following:

- Add a specific econ-ark version to `requirements.txt`, as #2.
- Also removes `pkg-resources==0.0.0` from `requirements.txt`, as it was causing binder to crash. The line itself seems to stem from an Ubuntu bug (see e.g., [this](https://github.com/pypa/pip/issues/4022)) and a Google search suggested that it could be safely removed.

I tested binder on my fork (with this edit) and it ran without issues.